### PR TITLE
Compatibility with clojure version 1.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,20 +4,22 @@
   :license      {:name "Eclipse Public License"
                  :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [
-    [org.clojure/clojure "1.8.0" :scope "provided"]
     [org.clojure/clojurescript "1.9.89" :scope "provided"]
-    [clojure-future-spec "1.9.0-alpha10"]
   ]
-  
+
   :global-vars { *warn-on-reflection* true }
-  
+
   :plugins [[lein-cljsbuild "1.1.3"]]
-  
-  :profiles {
-    :dev {
-      :jvm-opts ["-Dclojure.spec.check-asserts=true"]
-  }}
-  
+
+  :profiles {:1.8 {
+                   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
+                                  [clojure-future-spec "1.9.0-alpha10"]]}
+             :default [:leiningen/default :1.8]
+             :dev {
+                   :jvm-opts ["-Dclojure.spec.check-asserts=true"]}
+             :1.9 {
+                   :dependencies [[org.clojure/clojure "1.9.0-alpha10"]]}}
+
   :cljsbuild
   { :builds
     [{ :id "test"

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -4,9 +4,13 @@
     [tongue.inst :as inst]
     [tongue.number :as number]
     [tongue.macro :as macro]
-    #?(:clj [clojure.future :refer [simple-keyword? inst?]])
     #?(:clj [clojure.spec :as spec])))
 
+#?(:clj
+   (if (and
+        (= 1 (:major *clojure-version*))
+        (> 9 (:minor *clojure-version*)))
+     (require '[clojure.future :refer [simple-keyword? inst?]])))
 
 (def inst-formatter inst/formatter)
 

--- a/src/tongue/inst.cljc
+++ b/src/tongue/inst.cljc
@@ -1,13 +1,17 @@
 (ns tongue.inst
   (:require
     [clojure.string :as str]
-    #?(:clj [clojure.future :refer [simple-keyword? inst? inst-ms]])
     [tongue.macro :as macro]
     #?(:clj [clojure.spec :as spec]))
   #?(:clj
       (:import
         [java.util Calendar])))
 
+#?(:clj
+   (if (and
+        (= 1 (:major *clojure-version*))
+        (> 9 (:minor *clojure-version*)))
+     (require '[clojure.future :refer [simple-keyword? inst? inst-ms]])))
 
 (defn- pad2 [i]
   (if (< i 10)


### PR DESCRIPTION
Addresses tonsky/tongue#3

`tongue.core` and `tongue.inst` only require `clojure.future` in the case that the clojure version is less than 1.9

Default lein profile uses 1.8 as before. So `lein test` tests against 1.8.

You can test against latest 1.9 alpha with `lein with-profile 1.9 test` 