### PR TITLE
Regexp escape strings that are used as replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://dl.dropboxusercontent.com/u/561580/imgs/tongue_logo.svg">
+<img src="http://s.tonsky.me/imgs/tongue_logo.svg">
 
 [![tongue](https://img.shields.io/clojars/v/tongue.svg)](http://clojars.org/tongue) [![build status](https://img.shields.io/circleci/project/tonsky/tongue.svg)](https://circleci.com/gh/tonsky/tongue)
 

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -55,7 +55,7 @@
 
 (defn- regexp-escape [str]
   #?(:clj (java.util.regex.Matcher/quoteReplacement str)
-     :cljs (.replace str (js/RegExp. "[-\\/\\\\^$*+?.()|[\\]{}]" "g") "\\$&")))
+     :cljs str))
 
 
 (defn- format-argument [dicts locale x]

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -53,6 +53,11 @@
       (str "{Missing key " key "}")))
 
 
+(defn- regexp-escape [str]
+  #?(:clj (java.util.regex.Matcher/quoteReplacement str)
+     :cljs (.replace str (js/RegExp. "[-\\/\\\\^$*+?.()|[\\]{}]" "g") "\\$&")))
+
+
 (defn- format-argument [dicts locale x]
   (cond
     (number? x) (let [formatter (or (lookup-template-for-locale dicts locale :tongue/format-number)
@@ -61,7 +66,7 @@
     (inst? x)   (let [formatter (or (lookup-template-for-locale dicts locale :tongue/format-inst)
                                     format-inst-iso)]
                   (formatter x))
-    :else       (str x)))
+    :else       (regexp-escape (str x))))
 
 
 (macro/with-spec

--- a/test/tongue/test/core.cljc
+++ b/test/tongue/test/core.cljc
@@ -69,4 +69,8 @@
                                     :ru { :key "{1} значение" } })]
     (is (= "1000.1 value" (t :en :key 1000.1))) 
     (is (= "1000.1 значение" (t :ru :key 1000.1)))
-    (is (= "{Missing key :key}" (t :de :key 1000.1)))))
+    (is (= "{Missing key :key}" (t :de :key 1000.1))))
+
+  (testing "Should escape regexp characters in interpolated strings"
+    (let [t (tongue/build-translate { :en { :key "Here's my {1}" } })]
+      (is (= "Here's my $2.02" (t :en :key "$2.02"))))))


### PR DESCRIPTION
The current version of Tongue throws an exception if string arguments to translations contain certain characters that have special meaning in regular expressions. For instance, any text containing an amount in dollars will be interpreted as a back reference, and in most cases will throw. See the provided test (which throws under 0.2.0, and works as expected in this PR).