### PR TITLE
Enable deep nesting of dicts

### DIFF
--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -115,14 +115,14 @@
   "Collapses nested maps into namespaced keywords:
    { :ns { :key 1 }} => { :ns/key 1 }
    { :animal { :flying { :bird 420 }}} => { :animal.flying/bird 420 }"
-  ([dict] (reduce-dict dict ""))
+  ([dict] (build-dict dict ""))
   ([dict prefix]
     (reduce-kv
       (fn [aggr key value]
         (let [new-key (join-kws prefix key)]
           (println new-key)
           (if (map? value)
-            (merge aggr (reduce-dict value new-key))
+            (merge aggr (build-dict value new-key))
             (assoc aggr new-key value))))
       {} dict)))
 

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -102,7 +102,7 @@
                                       (format-argument dicts locale arg)))))))
 
 
-(defn join-kws
+(defn- join-kws
   [ns-key key]
   (keyword (if (and (keyword? ns-key) (namespace ns-key))
              (str (namespace ns-key) "." (name ns-key))

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -119,8 +119,9 @@
   ([dict prefix]
     (reduce-kv
       (fn [aggr key value]
-        (let [new-key (join-kws prefix key)]
-          (println new-key)
+        (let [new-key (if (= (namespace key) "tongue")
+                        key
+                        (join-kws prefix key))]
           (if (map? value)
             (merge aggr (build-dict value new-key))
             (assoc aggr new-key value))))

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -119,7 +119,7 @@
   ([dict prefix]
     (reduce-kv
       (fn [aggr key value]
-        (let [new-key (if (= (namespace key) "tongue")
+        (let [new-key (if (and (keyword? key) (= (namespace key) "tongue"))
                         key
                         (join-kws prefix key))]
           (if (map? value)

--- a/test/tongue/test/core.cljc
+++ b/test/tongue/test/core.cljc
@@ -13,8 +13,8 @@
                          :common "common"
                          :ns     { :a "A"
                                    :b "B"
-                                   :c { :hoge { :foo "FOO" }
-                                        :fuga { :bar "BAR" }}}
+                                   :c { "hoge" { :foo "FOO" }
+                                        "fuga" { :bar "BAR" }}}
                          :subst1 "one {1} argument"
                          :subst2 "two {1} {2} {1} arguments"
                          :subst3 "missing {1} {2} {3} argument"

--- a/test/tongue/test/core.cljc
+++ b/test/tongue/test/core.cljc
@@ -11,7 +11,10 @@
                 
                 :en    { :color  "color"
                          :common "common"
-                         :ns     { :a "A" :b "B" }
+                         :ns     { :a "A"
+                                   :b "B"
+                                   :c { :hoge { :foo "FOO" }
+                                        :fuga { :bar "BAR" }}}
                          :subst1 "one {1} argument"
                          :subst2 "two {1} {2} {1} arguments"
                          :subst3 "missing {1} {2} {3} argument"
@@ -49,6 +52,9 @@
       :en-GB :ns/b   [] "B"
       :en    :ns/a   [] "A"
       :en    :ns/b   [] "B"
+      ;; deeply nested
+      :en    :ns.c.hoge/foo [] "FOO"
+      :en    :ns.c.fuga/bar [] "BAR"
          
       ;; arguments
       :en    :subst1  ["A"]     "one A argument"


### PR DESCRIPTION
# Issue
Closes #17 

# Added
* `join-kws` for joining keywords where the first may be namespaced
* deep nesting test cases

# Changed
* updated `build-dict` to use `join-kws` for deep nesting