### PR TITLE
Feature/add substitution way fo map

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In production:
 
 In development:
 
-- Add `-Dclojure.spec.check-asserts=true` to JVM options. 
+- Add `-Dclojure.spec.check-asserts=true` to JVM options.
 
 ## Usage
 
@@ -48,20 +48,21 @@ Define dictionaries:
   { :en { ;; simple keys
           :color "Color"
           :flower "Flower"
-          
+
           ;; namespaced keys
           :weather/rain   "Rain"
           :weather/clouds "Clouds"
-          
+
           ;; nested maps will be unpacked into namespaced keys
           ;; this is purely for ease of dictionary writing
           :animals { :dog "Dog"   ;; => :animals/dog
                      :cat "Cat" } ;; => :animals/cat
-                     
+
           ;; substitutions
           :welcome "Hello, {1}!"
           :between "Value must be between {1} and {2}"
-          
+          :mail-title "%{user}, %{title} - Message received."
+
           ;; arbitrary functions
           :count (fn [x]
                    (cond
@@ -69,7 +70,7 @@ Define dictionaries:
                      (= 1 x)   "1 item"
                      :else     "{1} items")) ;; you can return string with substitutions
         }
-                   
+
     :en-GB { :color "colour" } ;; sublang overrides
     :tongue/fallback :en }     ;; fallback locale key
 ```
@@ -92,13 +93,14 @@ And go use it:
 ;; substitutions
 (translate :en :welcome "Nikita") ;; => "Hello, Nikita!"
 (translate :en :between 0 100) ;; => "Value must be between 0 and 100"
+(translate :en :mail-title {"user" "Tom" "title" "New message"}) ;; => "Tom, New message - Message received."
 
 ;; if key resolves to fn, it will be called with provided arguments
 (translate :en :count 0) ;; => "No items"
 (translate :en :count 1) ;; => "1 item"
 (translate :en :count 2) ;; => "2 items"
 
-;; multi-tag locales will fall back to more generic versions 
+;; multi-tag locales will fall back to more generic versions
 ;; :zh-Hans-CN will look in :zh-Hans-CN first, then :zh-Hans, then :zh, then fallback locale
 (translate :en-GB :color) ;; => "Colour", taken from :en-GB
 (translate :en-GB :flower) ;; => "Flower", taken from :en
@@ -118,7 +120,7 @@ Tongue can help you build localized number formatters:
 (def format-number-en ;; [number] => string
   (tongue/number-formatter { :group ","
                              :decimal "." }))
-                             
+
 (format-number-en 9999.9) ;; => "9,999.9"
 ```
 
@@ -207,7 +209,7 @@ Use multiple keys if you need several datetime format options:
 
 ```clj
 (def dicts
-  { :en 
+  { :en
     { :date-full     (tongue/inst-formatter "{month-long} {day}, {year}" inst-strings-en)
       :date-short    (tongue/inst-formatter "{month-numeric}/{day}/{year-2digit}" inst-strings-en)
       :time-military (tongue/inst-formatter "{hour24-padded}{minutes-padded}")}})
@@ -226,7 +228,7 @@ Use multiple keys if you need several datetime format options:
 
 Full list of formatting options:
 
-| Code                 | Example        | Meaning              | 
+| Code                 | Example        | Meaning              |
 | -------------------- | -------------- | -------------------- |
 | `{hour24-padded}`    | 00, 09, 12, 23 | Hour of day (00-23), 0-padded |
 | `{hour24}`           | 0, 9, 12, 23   | Hour of day (0-23) |

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Define dictionaries:
           ;; substitutions
           :welcome "Hello, {1}!"
           :between "Value must be between {1} and {2}"
-          ;; For using same dictionary formats with other programming languages
-          :mail-title "%{user}, %{title} - Message received."
+          ;; For using a map
+          :mail-title "{user}, {title} - Message received."
 
           ;; arbitrary functions
           :count (fn [x]
@@ -94,7 +94,7 @@ And go use it:
 ;; substitutions
 (translate :en :welcome "Nikita") ;; => "Hello, Nikita!"
 (translate :en :between 0 100) ;; => "Value must be between 0 and 100"
-(translate :en :mail-title {"user" "Tom" "title" "New message"}) ;; => "Tom, New message - Message received."
+(translate :en :mail-title {:user "Tom" :title "New message"}) ;; => "Tom, New message - Message received."
 
 ;; if key resolves to fn, it will be called with provided arguments
 (translate :en :count 0) ;; => "No items"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Define dictionaries:
           ;; substitutions
           :welcome "Hello, {1}!"
           :between "Value must be between {1} and {2}"
+          ;; For using same dictionary formats with other programming languages
           :mail-title "%{user}, %{title} - Message received."
 
           ;; arbitrary functions

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -88,7 +88,12 @@
       (spec/assert ::key key))
     (let [t (lookup-template dicts locale key)
           s (if (ifn? t) (t x) t)]
-      (str/replace s #"\{1\}" (escape-re-subst (format-argument dicts locale x)))))
+      (if (map? x)
+        (str/replace s #"%?\{(\w+)\}"
+                     (fn [[_ k]]
+                       (format-argument dicts locale (get x k))))
+        (str/replace s #"%?\{1\}"
+                     (escape-re-subst (format-argument dicts locale x))))))
   ([dicts locale key x & rest]
     (macro/with-spec
       (spec/assert ::locale locale)
@@ -96,10 +101,12 @@
     (let [args (cons x rest)
           t    (lookup-template dicts locale key)
           s    (if (ifn? t) (apply t x rest) t)]
-      (str/replace s #"\{(\d+)\}" (fn [[_ n]]
-                                    (let [idx (parse-long n)
-                                          arg (nth args (dec idx) (str "{Missing index " idx "}"))]
-                                      (format-argument dicts locale arg)))))))
+      (str/replace s #"%?\{(\d+)\}"
+                   (fn [[_ n]]
+                     (let [idx (parse-long n)
+                           arg (nth args (dec idx)
+                                    (str "{Missing index " idx "}"))]
+                       (format-argument dicts locale arg)))))))
 
 
 (defn- append-ns [ns segment]
@@ -130,7 +137,7 @@
 
 
 (defn- build-dicts [dicts]
-  (reduce-kv 
+  (reduce-kv
     (fn [acc lang dict]
       (assoc acc lang (if (map? dict) (build-dict dict) dict)))
     {} dicts))

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -91,7 +91,7 @@
       (if (map? x)
         (str/replace s #"%?\{(\w+)\}"
                      (fn [[_ k]]
-                       (format-argument dicts locale (get x k))))
+                       (format-argument dicts locale (get x (keyword k)))))
         (str/replace s #"%?\{1\}"
                      (escape-re-subst (format-argument dicts locale x))))))
   ([dicts locale key x & rest]

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -89,10 +89,10 @@
     (let [t (lookup-template dicts locale key)
           s (if (ifn? t) (t x) t)]
       (if (map? x)
-        (str/replace s #"%?\{(\w+)\}"
+        (str/replace s #"\{(\w+)\}"
                      (fn [[_ k]]
                        (format-argument dicts locale (get x (keyword k)))))
-        (str/replace s #"%?\{1\}"
+        (str/replace s #"\{1\}"
                      (escape-re-subst (format-argument dicts locale x))))))
   ([dicts locale key x & rest]
     (macro/with-spec
@@ -101,7 +101,7 @@
     (let [args (cons x rest)
           t    (lookup-template dicts locale key)
           s    (if (ifn? t) (apply t x rest) t)]
-      (str/replace s #"%?\{(\d+)\}"
+      (str/replace s #"\{(\d+)\}"
                    (fn [[_ n]]
                      (let [idx (parse-long n)
                            arg (nth args (dec idx)

--- a/test/tongue/test/core.cljc
+++ b/test/tongue/test/core.cljc
@@ -24,7 +24,6 @@
                          :subst2    "two {1} {2} {1} arguments"
                          :subst3    "missing {1} {2} {3} argument"
                          :subst4    "{arg1} {arg2} map arguments"
-                         :subst5    "%{arg1} %{arg2} map arguments in case of same dictionary format with other programming languages"
                          :args      (fn [& args] (pr-str args))
                          :plural    (fn [x]
                                       (cond
@@ -70,7 +69,6 @@
       :en    :subst2  ["A" "B"] "two A B A arguments"
       :en    :subst3  ["A" "B"] "missing A B {Missing index 3} argument"
       :en    :subst4  [{:arg1 "A" :arg2 "B"}] "A B map arguments"
-      :en    :subst5  [{:arg1 "A" :arg2 "B"}] "A B map arguments in case of same dictionary format with other programming languages"
 
       ;; fns
       :en    :args   ["A"]     "(\"A\")"

--- a/test/tongue/test/core.cljc
+++ b/test/tongue/test/core.cljc
@@ -21,9 +21,10 @@
                                            :fuga { :bar "BAR" }}}
                          :ns/in-key "namespace in key"
                          :subst1    "one {1} argument"
-                         :subst2    "two {1} {2} %{1} arguments"
+                         :subst2    "two {1} {2} {1} arguments"
                          :subst3    "missing {1} {2} {3} argument"
-                         :subst4    "%{arg1} {arg2} map arguments"
+                         :subst4    "{arg1} {arg2} map arguments"
+                         :subst5    "%{arg1} %{arg2} map arguments in case of same dictionary format with other programming languages"
                          :args      (fn [& args] (pr-str args))
                          :plural    (fn [x]
                                       (cond
@@ -68,7 +69,8 @@
       :en    :subst1  ["A"]     "one A argument"
       :en    :subst2  ["A" "B"] "two A B A arguments"
       :en    :subst3  ["A" "B"] "missing A B {Missing index 3} argument"
-      :en    :subst4  [{"arg1" "A" "arg2" "B"}] "A B map arguments"
+      :en    :subst4  [{:arg1 "A" :arg2 "B"}] "A B map arguments"
+      :en    :subst5  [{:arg1 "A" :arg2 "B"}] "A B map arguments in case of same dictionary format with other programming languages"
 
       ;; fns
       :en    :args   ["A"]     "(\"A\")"

--- a/test/tongue/test/core.cljc
+++ b/test/tongue/test/core.cljc
@@ -21,8 +21,9 @@
                                            :fuga { :bar "BAR" }}}
                          :ns/in-key "namespace in key"
                          :subst1    "one {1} argument"
-                         :subst2    "two {1} {2} {1} arguments"
+                         :subst2    "two {1} {2} %{1} arguments"
                          :subst3    "missing {1} {2} {3} argument"
+                         :subst4    "%{arg1} {arg2} map arguments"
                          :args      (fn [& args] (pr-str args))
                          :plural    (fn [x]
                                       (cond
@@ -39,19 +40,19 @@
 
                 :tongue/fallback :en-US }
         translate (tongue/build-translate dicts)]
-    
+
     (are [l k a t] (= (apply translate l k a) t)
       :en-GB :color  [] "colour"
-      :en    :color  [] "color"   
+      :en    :color  [] "color"
       :ru    :color  [] "цвет"
-         
+
       ;; fallbacks
       :en-GB     :common [] "common"               ;; :en-GB => :en
       :en-GB-inf :color  [] "colour"               ;; :en-GB-inf => :en-GB
       :en-GB-inf :common [] "common"               ;; :en-GB-inf => :en-GB => :en
       :de        :color  [] "color"                ;; :de => :tongue/fallback => :en-US => :en
       :en-GB     :unknw  [] "{Missing key :unknw}" ;; missing key
-         
+
       ;; nested
       :en-GB :ns/a   [] "a"
       :en-GB :ns/b   [] "B"
@@ -62,12 +63,13 @@
       :en    :ns.c.fuga/bar [] "BAR"
       ;; in the key
       :en    :ns/in-key [] "namespace in key"
-         
+
       ;; arguments
       :en    :subst1  ["A"]     "one A argument"
       :en    :subst2  ["A" "B"] "two A B A arguments"
       :en    :subst3  ["A" "B"] "missing A B {Missing index 3} argument"
-         
+      :en    :subst4  [{"arg1" "A" "arg2" "B"}] "A B map arguments"
+
       ;; fns
       :en    :args   ["A"]     "(\"A\")"
       :en    :args   ["A" "B"] "(\"A\" \"B\")"
@@ -77,12 +79,12 @@
       :ru    :plural [0]       "ничего"
       :ru    :plural [1]       "1 штука"
       :ru    :plural [5]       "5 штук"))
-  
-  
+
+
   ;; should work without :tongue/fallback
   (let [t (tongue/build-translate { :en { :key "{1} value" }
                                     :ru { :key "{1} значение" } })]
-    (is (= "1000.1 value" (t :en :key 1000.1))) 
+    (is (= "1000.1 value" (t :en :key 1000.1)))
     (is (= "1000.1 значение" (t :ru :key 1000.1)))
     (is (= "{Missing key :key}" (t :de :key 1000.1)))))
 
@@ -90,7 +92,7 @@
 (deftest test-regex-escape
   (let [t (tongue/build-translate { :en { :key "Here's my {1}" } })]
     (is (= "Here's my $1.02 $&" (t :en :key "$1.02 $&"))))
-  
+
   (let [t (tongue/build-translate { :en { :key "Here's my {1} {2} {3}" } })]
     (is (= "Here's my $1.3 $2.x $&" (t :en :key "$1.3" "$2.x" "$&")))))
 


### PR DESCRIPTION
## Issues
#21 Add a substitution way for map

## Fixes
* Add process that Map data can be used for substitute variables
* Add a regex pattern `%{xxx}` like other programming language's i18n process