### PR TITLE
Change regular expression to capture kebab-case map arguments.

### DIFF
--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -89,7 +89,7 @@
     (let [t (lookup-template dicts locale key)
           s (if (ifn? t) (t x) t)]
       (if (map? x)
-        (str/replace s #"\{(\w+)\}"
+        (str/replace s #"\{([\w-]+)\}"
                      (fn [[_ k]]
                        (format-argument dicts locale (get x (keyword k)))))
         (str/replace s #"\{1\}"

--- a/test/tongue/test/core.cljc
+++ b/test/tongue/test/core.cljc
@@ -24,6 +24,7 @@
                          :subst2    "two {1} {2} {1} arguments"
                          :subst3    "missing {1} {2} {3} argument"
                          :subst4    "{arg1} {arg2} map arguments"
+                         :subst5    "{foo-bar} {baz-qux} kebab-cased map arguments"
                          :args      (fn [& args] (pr-str args))
                          :plural    (fn [x]
                                       (cond
@@ -69,6 +70,7 @@
       :en    :subst2  ["A" "B"] "two A B A arguments"
       :en    :subst3  ["A" "B"] "missing A B {Missing index 3} argument"
       :en    :subst4  [{:arg1 "A" :arg2 "B"}] "A B map arguments"
+      :en    :subst5  [{:foo-bar "A" :baz-qux "B"}] "A B kebab-cased map arguments"
 
       ;; fns
       :en    :args   ["A"]     "(\"A\")"


### PR DESCRIPTION
Currently the usage of a map keys, for variable injection into a translation string, are limited to \w characters. This leaves out the "-" character which is used in kebab-case, a staple of Clojure variable names. This pull request extends the capture group to include this "-". As a user of Tongue I expect to be able to use reasonably conventional keys when using this injection functionality.