### PR TITLE
Make build-dicts public

### DIFF
--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -137,7 +137,7 @@
       {} dict)))
 
 
-(defn- build-dicts [dicts]
+(defn build-dicts [dicts]
   (reduce-kv
     (fn [acc lang dict]
       (assoc acc lang (if (map? dict) (build-dict dict) dict)))


### PR DESCRIPTION
Very useful when writing tests that verify that all keys are present in
every language.

Would it make sense to also include a helper function for checking that in the library?