### PR TITLE
Make interpolations extensive via a new protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Now you can put vectors in the dictionary and have values interpolated in them:
 
 (def dicts
   { :en { :welcome [:div {} "Hello, " [:arg 0]]
-          :mail-title [{:arg/user} ", Message received."]
+          :mail-title [:arg/user ", Message received."]
         }})
 
 (def tr (tongue/build-translate dicts))

--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -101,19 +101,23 @@
   (spec/def ::key keyword?))
 
 
+(defn- invoke? [t]
+  (and (ifn? t) (not (satisfies? IInterpolate t))))
+
+
 (defn- translate
   ([dicts locale key]
     (macro/with-spec
       (spec/assert ::locale locale)
       (spec/assert ::key key))
     (let [t (lookup-template dicts locale key)]
-      (if (ifn? t) (t) t)))
+      (if (invoke? t) (t) t)))
   ([dicts locale key x]
     (macro/with-spec
       (spec/assert ::locale locale)
       (spec/assert ::key key))
     (let [t (lookup-template dicts locale key)
-          v (if (ifn? t) (t x) t)]
+          v (if (invoke? t) (t x) t)]
       (if (map? x)
         (interpolate-named v dicts locale x)
         (interpolate-positional v dicts locale [x]))))
@@ -123,7 +127,7 @@
       (spec/assert ::key key))
     (let [args (cons x rest)
           t (lookup-template dicts locale key)]
-      (interpolate-positional (if (ifn? t) (apply t x rest) t) dicts locale args))))
+      (interpolate-positional (if (invoke? t) (apply t x rest) t) dicts locale args))))
 
 
 (defn- append-ns [ns segment]


### PR DESCRIPTION
As suggested in #11, this adds a protocol for interpolations that allows consumers to put other kinds of data in dictionaries than strings. It does not add any new features to Tongue - it does not support anything other than strings out of the box - but it gives users a bit more flexibility.

A few things to consider:

- I debated between one or two interpolation functions, and decided it was best to separate them - one for maps, and one for positional arguments. It is two distinct features in Tongue, and leaving the decision up to the protocol would put too much knowledge about the internals of Tongue into the protocol.
- I'm not ecstatic about the names `interpolate-named` and `interpolate-positional` (seems rather long), but they're accurate and the best I could think of.
- The protocol could easily also be named `IInterpolatable` - Clojure uses both kinds of names internally, and I don't have a strong preference either or.