### PR TITLE
Implement the interpolate protocol for strings without modifying String.prototype

### DIFF
--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -79,7 +79,7 @@
 
 
 (extend-type #?(:clj String
-                :cljs js/String)
+                :cljs string)
   IInterpolate
   (interpolate-named [s dicts locale interpolations]
     (str/replace s #?(:clj  #"\{([\w*!_?$%&=<>'\-+.#0-9]+|[\w*!_?$%&=<>'\-+.#0-9]+\/[\w*!_?$%&=<>'\-+.#0-9:]+)\}"


### PR DESCRIPTION
I'm sorry, but my previous PR extended a protocol to `js/String` in ClojureScript. Turns out that that effectively modifies `String.prototype`. Using the symbolic value `string` as target for `extend-type` is the safe way to implement protocols to built-ins in ClojureScript.