### PR TITLE
Make format-argument fn public

### DIFF
--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -59,7 +59,7 @@
      :cljs (str/replace str #"\$" "$$$$")))
 
 
-(defn- format-argument [dicts locale x]
+(defn format-argument [dicts locale x]
   (cond
     (number? x) (let [formatter (or (lookup-template-for-locale dicts locale :tongue/format-number)
                                     str)]


### PR DESCRIPTION
To allow implementations of `tongue.core/IInterpolate` to use tongue's formatting machinery.