### PR TITLE
Exclude clojure.core/parse-long (v1.11) in tongue.core

### DIFF
--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -1,4 +1,5 @@
 (ns tongue.core
+  (:refer-clojure :exclude [parse-long])
   (:require
     [clojure.string :as str]
     [tongue.inst :as inst]


### PR DESCRIPTION
Fixes #35

## All tests pass

```
--- Testing on Clojure 1.10.0 ---

<snip>

Ran 9 tests containing 117 assertions.
0 failures, 0 errors.

<snip>

--- Testing on Clojure 1.8.0 ---

<snip>

Ran 9 tests containing 117 assertions.
0 failures, 0 errors.

<snip>

--- Testing on ClojureScript ---

<snip>

Ran 9 tests containing 116 assertions.
0 failures, 0 errors.
```