### PR TITLE
Functional interpolation

### DIFF
--- a/src/tongue/core.cljc
+++ b/src/tongue/core.cljc
@@ -96,7 +96,7 @@
     (str/replace s #?(:clj  #"\{([\w*!_?$%&=<>'\-+.#0-9]+|[\w*!_?$%&=<>'\-+.#0-9]+\/[\w*!_?$%&=<>'\-+.#0-9:]+)\}"
                       :cljs #"\{([\w*!_?$%&=<>'\-+.#0-9]+|[\w*!_?$%&=<>'\-+.#0-9]+/[\w*!_?$%&=<>'\-+.#0-9:]+)\}")
                  (fn [[_ k]]
-                   (format-argument dicts locale (get interpolations (keyword k))))))
+                   (format-argument dicts locale (interpolations (keyword k))))))
 
   (interpolate-positional [s dicts locale interpolations]
     (str/replace s #"\{(\d+)\}"
@@ -139,7 +139,7 @@
      (spec/assert ::key key))
    (macro/if-some-reduced [t (lookup-template dicts locale key)]
      (let [v (if (invoke? t) (t x) t)]
-       (if (map? x)
+       (if (or (map? x) (fn? x))
          (interpolate-named v dicts locale x)
          (interpolate-positional v dicts locale [x])))
      (translate-missing dicts locale key)))

--- a/test/tongue/test/core.cljc
+++ b/test/tongue/test/core.cljc
@@ -152,4 +152,16 @@
     (is (= nil (t :ru :unknown)))
     (is (= nil (t :ru-RU :unknown)))))
 
+(deftest test-functional-interpolation
+  (let [translate (tongue/build-translate {:en-GB {:country "the UK"}
+                                           :en-US {:country "the US"}
+                                           :en {:welcome "Welcome to {country}!"}
+                                           :ru {:welcome "Добро пожаловать в Россию!"}})
+        message (fn message [locale k]
+                  (translate locale k (partial message locale)))]
+    (are [l t] (= (message l :welcome) t)
+      :en-GB "Welcome to the UK!"
+      :en-US "Welcome to the US!"
+      :ru-RU "Добро пожаловать в Россию!")))
+
 #_(clojure.test/test-vars [#'test-errors])


### PR DESCRIPTION
# What

This PR allows to pass a function instead of a map to `translate` for interpolation. E.g. assuming `translate` is a result of calling `build-translate`, where previously you could do

```clojure
(translate :en :hello {:name "world"}) ;=> "Hello, world!"
```

you can now also do:

```clojure
(translate :en :hello #(if (= % :name) "world" "dunno")) ;=> "Hello, world!"
```

# Why

To make Tongue more dynamic. For example, the third arg could be a generic resolver that looks up keys in a DB or some third-party API.

My specific use case is to be able to create a wrapper around `translate` that passes itself as an interpolate fn, recursively. This allows you to have specific substrings that can be used within larger, more generic translations. I have added a test that illustrates this.

I guess it might be potentially beneficial to enable this recursive behaviour in `build-translate` itself, without having to write a wrapper, but this might break backwards compatibility. As it stands, the PR is conservative, allowing recursive lookup as an opt-in.